### PR TITLE
Updating project initialization command

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -12,7 +12,7 @@ To initialize a project with gauge-python, in an empty directory run:
 
     .. code:: sh
 
-        $ gauge --init python
+        $ gauge init python
 
     The project structure should look like this:
 


### PR DESCRIPTION
According to help displayed for gauge, a proper command for project initialization is 
`gauge init python` 
and it works (checked).
`gauge --init python`  is invalid.

Checked on Windows 10 cmd