### PR TITLE
Updating execution command

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -40,7 +40,7 @@ To execute a gauge-python project, run the following command in the project:
 
     .. code:: sh
 
-        $ gauge specs/
+        $ gauge run specs/
 
     .. _Gauge documentation: http://getgauge.io/documentation/user/current/
 


### PR DESCRIPTION
According to help displayed for gauge, a proper command for project execution is
`gauge run specs/`
and it works (checked).
`gauge specs/` is invalid.

Checked on Windows 10 cmd