### PR TITLE
Simplify data store API to be more pythonic

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -175,7 +175,8 @@ Data Stores
 
 Step implementations can share custom data across scenarios, specifications and suites using data stores.
 There are 3 different types of data stores based on the lifecycle of when it gets cleared.
-These data stores provide a dict like interface for managing data.
+These data stores provide a dict like interface for managing data. In addition to this, data keys
+can also be accessed as attributes for convenience.
 
 Scenario store
 ^^^^^^^^^^^^^^
@@ -188,12 +189,16 @@ This data store keeps values added to it in the lifecycle of the scenario execut
 
     from getgauge.python import data_store
     data_store.scenario[key] = value
+    # OR
+    data_store.scenario.key = value
 
 **Retrieve a value:**
 
 .. code::
 
     data_store.scenario[key]
+    # OR
+    data_store.scenario.key
 
 Specification store
 ^^^^^^^^^^^^^^^^^^^
@@ -208,12 +213,16 @@ executes.
 
     from getgauge.python import data_store
     data_store.spec[key] = value
+    # OR
+    data_store.spec.key = value
 
 **Retrieve a value:**
 
 .. code::
 
     data_store.spec[key]
+    # OR
+    data_store.spec.key
 
 Suite store
 ^^^^^^^^^^^
@@ -227,12 +236,16 @@ suite’s execution. Values are cleared after entire suite executes.
 
     from getgauge.python import data_store
     data_store.suite[key] = value
+    # OR
+    data_store.suite.key = value
 
 **Retrieve a value:**
 
 .. code::
 
     data_store.suite[key]
+    # OR
+    data_store.suite.key
 
 .. note::
     Suite Store is not advised to be used when executing specs in parallel. The values are not retained between parallel streams of execution.

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -175,6 +175,7 @@ Data Stores
 
 Step implementations can share custom data across scenarios, specifications and suites using data stores.
 There are 3 different types of data stores based on the lifecycle of when it gets cleared.
+These data stores provide a dict like interface for managing data.
 
 Scenario store
 ^^^^^^^^^^^^^^
@@ -185,14 +186,14 @@ This data store keeps values added to it in the lifecycle of the scenario execut
 
 .. code::
 
-    from getgauge.python import DataStoreFactory
-    DataStoreFactory.scenario_data_store().put(key, value)
+    from getgauge.python import data_store
+    data_store.scenario[key] = value
 
 **Retrieve a value:**
 
 .. code::
 
-    DataStoreFactory.scenario_data_store().get(key)
+    data_store.scenario[key]
 
 Specification store
 ^^^^^^^^^^^^^^^^^^^
@@ -205,14 +206,14 @@ executes.
 
 .. code::
 
-    from getgauge.python import DataStoreFactory
-    DataStoreFactory.spec_data_store().put(key, value)
+    from getgauge.python import data_store
+    data_store.spec[key] = value
 
 **Retrieve a value:**
 
 .. code::
 
-    DataStoreFactory.spec_data_store().get(key)
+    data_store.spec[key]
 
 Suite store
 ^^^^^^^^^^^
@@ -224,14 +225,14 @@ suite’s execution. Values are cleared after entire suite executes.
 
 .. code::
 
-    from getgauge.python import DataStoreFactory
-    DataStoreFactory.suite_data_store().put(key, value);
+    from getgauge.python import data_store
+    data_store.suite[key] = value
 
 **Retrieve a value:**
 
 .. code::
 
-    DataStoreFactory.suite_data_store().get(key);
+    data_store.suite[key]
 
 .. note::
     Suite Store is not advised to be used when executing specs in parallel. The values are not retained between parallel streams of execution.

--- a/getgauge/processor.py
+++ b/getgauge/processor.py
@@ -5,14 +5,13 @@ from os import path, environ
 from threading import Timer
 
 import ptvsd
-import time
 
 from getgauge.connection import read_message, send_message
 from getgauge.executor import set_response_values, execute_method, run_hook
 from getgauge.impl_loader import load_impls
 from getgauge.messages.messages_pb2 import Message, StepPositionsResponse, TextDiff, CacheFileRequest
 from getgauge.messages.spec_pb2 import Parameter, Span
-from getgauge.python import Table, create_execution_context_from, DataStoreFactory
+from getgauge.python import Table, create_execution_context_from, data_store
 from getgauge.refactor import refactor_step
 from getgauge.registry import registry, MessagesStore
 from getgauge.static_loader import reload_steps
@@ -141,17 +140,17 @@ def _execute_after_step_hook(request, response, _socket):
 
 
 def _init_scenario_data_store(request, response, _socket):
-    DataStoreFactory.scenario_data_store().clear()
+    data_store.scenario.clear()
     set_response_values(request, response)
 
 
 def _init_spec_data_store(request, response, _socket):
-    DataStoreFactory.spec_data_store().clear()
+    data_store.spec.clear()
     set_response_values(request, response)
 
 
 def _init_suite_data_store(request, response, _socket):
-    DataStoreFactory.suite_data_store().clear()
+    data_store.suite.clear()
     set_response_values(request, response)
 
 

--- a/getgauge/python.py
+++ b/getgauge/python.py
@@ -221,9 +221,33 @@ class Messages:
         MessagesStore.write_message(message)
 
 
-class DataStore:
+class DataStoreContainer(object):
     def __init__(self):
-        self.__data_store = {}
+        self.__scenario = {}
+        self.__spec = {}
+        self.__suite = {}
+
+    @property
+    def scenario(self):
+        return self.__scenario
+
+    @property
+    def spec(self):
+        return self.__spec
+
+    @property
+    def suite(self):
+        return self.__suite
+
+
+data_store = DataStoreContainer()
+
+
+class DataStore:
+    def __init__(self, data_store=None):
+        if data_store is None:
+            data_store = {}
+        self.__data_store = data_store
 
     def get(self, key):
         return self.__data_store[key]
@@ -235,16 +259,16 @@ class DataStore:
         return key in self.__data_store
 
     def clear(self):
-        self.__data_store = {}
+        self.__data_store.clear()
 
     def __eq__(self, other):
         return self.__data_store == other.__data_store
 
 
 class DataStoreFactory:
-    __scenario_data_store = DataStore()
-    __spec_data_store = DataStore()
-    __suite_data_store = DataStore()
+    __scenario_data_store = DataStore(data_store.scenario)
+    __spec_data_store = DataStore(data_store.spec)
+    __suite_data_store = DataStore(data_store.suite)
 
     @staticmethod
     def scenario_data_store():

--- a/getgauge/python.py
+++ b/getgauge/python.py
@@ -1,5 +1,6 @@
 import inspect
 import sys
+import warnings
 
 from getgauge.registry import registry, MessagesStore
 
@@ -287,6 +288,13 @@ class DataStore:
         return self.__data_store == other.__data_store
 
 
+def _warn_datastore_deprecation(store_type):
+    warnings.warn(
+        "'DataStoreFactory.{0}_data_store()' is deprecated in favour of 'data_store.{0}'".format(store_type),
+        DeprecationWarning, stacklevel=3)
+    warnings.simplefilter('default', DeprecationWarning)
+
+
 class DataStoreFactory:
     __scenario_data_store = DataStore(data_store.scenario)
     __spec_data_store = DataStore(data_store.spec)
@@ -294,14 +302,17 @@ class DataStoreFactory:
 
     @staticmethod
     def scenario_data_store():
+        _warn_datastore_deprecation("scenario")
         return DataStoreFactory.__scenario_data_store
 
     @staticmethod
     def spec_data_store():
+        _warn_datastore_deprecation("spec")
         return DataStoreFactory.__spec_data_store
 
     @staticmethod
     def suite_data_store():
+        _warn_datastore_deprecation("suite")
         return DataStoreFactory.__suite_data_store
 
 

--- a/getgauge/python.py
+++ b/getgauge/python.py
@@ -3,6 +3,11 @@ import sys
 
 from getgauge.registry import registry, MessagesStore
 
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
+
 
 def step(step_text):
     def _step(func):
@@ -221,11 +226,28 @@ class Messages:
         MessagesStore.write_message(message)
 
 
+class DictObject(dict):
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError("'{0}' object has no attribute '{1}'".format(self.__class__.__name__, name))
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+    def __delattr__(self, name):
+        try:
+            del self[name]
+        except KeyError:
+            raise AttributeError("'{0}' object has no attribute '{1}'".format(self.__class__.__name__, name))
+
+
 class DataStoreContainer(object):
     def __init__(self):
-        self.__scenario = {}
-        self.__spec = {}
-        self.__suite = {}
+        self.__scenario = DictObject()
+        self.__spec = DictObject()
+        self.__suite = DictObject()
 
     @property
     def scenario(self):

--- a/skel/step_impl/step_impl.py
+++ b/skel/step_impl/step_impl.py
@@ -1,8 +1,9 @@
-from getgauge.python import step, before_scenario, Messages, data_store
+from getgauge.python import step, before_scenario, Messages
+
+vowels = ["a", "e", "i", "o", "u"]
 
 
 def number_of_vowels(word):
-    vowels = data_store.scenario["vowels"]
     return len([elem for elem in list(word) if elem in vowels])
 
 
@@ -17,7 +18,6 @@ def assert_no_of_vowels_in(word, number):
 
 @step("Vowels in English language are <vowels>.")
 def assert_default_vowels(given_vowels):
-    vowels = data_store.scenario["vowels"]
     Messages.write_message("Given vowels are {0}".format(given_vowels))
     assert given_vowels == "".join(vowels)
 
@@ -35,4 +35,4 @@ def assert_words_vowel_count(table):
 
 @before_scenario()
 def before_scenario_hook():
-    data_store.scenario["vowels"] = ["a", "e", "i", "o", "u"]
+    assert "".join(vowels) == "aeiou"

--- a/skel/step_impl/step_impl.py
+++ b/skel/step_impl/step_impl.py
@@ -1,9 +1,8 @@
-from getgauge.python import step, before_scenario, Messages
-
-vowels = ["a", "e", "i", "o", "u"]
+from getgauge.python import step, before_scenario, Messages, data_store
 
 
 def number_of_vowels(word):
+    vowels = data_store.scenario["vowels"]
     return len([elem for elem in list(word) if elem in vowels])
 
 
@@ -18,6 +17,7 @@ def assert_no_of_vowels_in(word, number):
 
 @step("Vowels in English language are <vowels>.")
 def assert_default_vowels(given_vowels):
+    vowels = data_store.scenario["vowels"]
     Messages.write_message("Given vowels are {0}".format(given_vowels))
     assert given_vowels == "".join(vowels)
 
@@ -35,4 +35,4 @@ def assert_words_vowel_count(table):
 
 @before_scenario()
 def before_scenario_hook():
-    assert "".join(vowels) == "aeiou"
+    data_store.scenario["vowels"] = ["a", "e", "i", "o", "u"]

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -8,16 +8,16 @@ from getgauge import static_loader as loader
 from getgauge.messages.messages_pb2 import Message, StepValidateResponse, TextDiff, CacheFileRequest
 from getgauge.messages.spec_pb2 import ProtoExecutionResult, Parameter, Span
 from getgauge.processor import processors
-from getgauge.python import DataStoreFactory, DataStore
+from getgauge.python import data_store
 from getgauge.registry import registry
 
 
 class ProcessorTests(TestCase):
     def setUp(self):
         self.setUpPyfakefs()
-        DataStoreFactory.suite_data_store().clear()
-        DataStoreFactory.spec_data_store().clear()
-        DataStoreFactory.scenario_data_store().clear()
+        data_store.suite.clear()
+        data_store.spec.clear()
+        data_store.scenario.clear()
         registry.clear()
 
     def tearDown(self):
@@ -31,9 +31,9 @@ class ProcessorTests(TestCase):
                                                           SOCK_STREAM))
 
     def test_Processor_suite_data_store_init_request(self):
-        DataStoreFactory.suite_data_store().put('suite', 'value')
+        data_store.suite['suite'] = 'value'
 
-        self.assertNotEqual(DataStore(), DataStoreFactory.suite_data_store())
+        self.assertNotEqual(0, len(data_store.suite))
 
         response = Message()
         processors[Message.SuiteDataStoreInit](None, response, None)
@@ -45,12 +45,12 @@ class ProcessorTests(TestCase):
         self.assertEqual(0,
                          response.executionStatusResponse.executionResult.executionTime)
 
-        self.assertEqual(DataStore(), DataStoreFactory.suite_data_store())
+        self.assertDictEqual({}, data_store.suite)
 
     def test_Processor_spec_data_store_init_request(self):
-        DataStoreFactory.spec_data_store().put('spec', 'value')
+        data_store.spec['spec'] = 'value'
 
-        self.assertNotEqual(DataStore(), DataStoreFactory.spec_data_store())
+        self.assertNotEqual(0, len(data_store.spec))
 
         response = Message()
         processors[Message.SpecDataStoreInit](None, response, None)
@@ -59,12 +59,12 @@ class ProcessorTests(TestCase):
         self.assertEqual(False, response.executionStatusResponse.executionResult.failed)
         self.assertEqual(0, response.executionStatusResponse.executionResult.executionTime)
 
-        self.assertEqual(DataStore(), DataStoreFactory.spec_data_store())
+        self.assertDictEqual({}, data_store.spec)
 
     def test_Processor_scenario_data_store_init_request(self):
-        DataStoreFactory.scenario_data_store().put('scenario', 'value')
+        data_store.scenario['scenario'] = 'value'
 
-        self.assertNotEqual(DataStore(), DataStoreFactory.scenario_data_store())
+        self.assertNotEqual(0, len(data_store.scenario))
 
         response = Message()
         processors[Message.ScenarioDataStoreInit](None, response, None)
@@ -73,7 +73,7 @@ class ProcessorTests(TestCase):
         self.assertEqual(False, response.executionStatusResponse.executionResult.failed)
         self.assertEqual(0, response.executionStatusResponse.executionResult.executionTime)
 
-        self.assertEqual(DataStore(), DataStoreFactory.scenario_data_store())
+        self.assertDictEqual({}, data_store.scenario)
 
     def test_Processor_step_names_request(self):
         registry.add_step('Step <a> with <b>', 'func', '')

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -2,9 +2,10 @@ from unittest import TestCase, main
 
 from getgauge.messages.messages_pb2 import Message
 from getgauge.registry import registry, MessagesStore
-from getgauge.python import (Messages, DataStore, DataStoreFactory, data_store,
-                             DataStoreContainer, Table, Specification, Scenario,
-                             Step, ExecutionContext, create_execution_context_from)
+from getgauge.python import (Messages, DataStore, DataStoreFactory, DictObject,
+                             DataStoreContainer, data_store, Table, Specification,
+                             Scenario, Step, ExecutionContext,
+                             create_execution_context_from)
 try:
     from collections.abc import MutableMapping
 except ImportError:
@@ -166,6 +167,27 @@ class DataStoreFactoryTests(TestCase):
 
             proxy.clear()
             self.assertDictEqual(store, {})
+
+
+class DictObjectTests(TestCase):
+    def test_attribute_access(self):
+        store = DictObject()
+
+        store['a'] = 'alpha'
+        self.assertEqual(store.a, 'alpha')
+
+        store.clear()
+        with self.assertRaises(AttributeError):
+            store.a
+
+        store.b = 'beta'
+        self.assertIn('b', store)
+        del store.b
+        self.assertNotIn('b', store)
+
+        store['k e y'] = 'value'
+        with self.assertRaises(AttributeError):
+            store.k
 
 
 class DataStoreContainerTests(TestCase):


### PR DESCRIPTION
Change the data store API to be more pythonic by exposing data store as a dictionary. With this change data store can be accessed as follows:
```python
from getgauge import step, data_store

@step("description")
def step_fn():
	data_store.scenario['key1'] = 'value'
    data_store.spec.key2 = 'value'
	print(data_store.scenario.key1)
    print(data_store.spec["key2"])

```

I have added the ability to access keys as attributes directly. However, it can be easily removed by reverting latest commit in the branch.

Fixes #93 