### PR TITLE
Static loader improvements

### DIFF
--- a/getgauge/python.py
+++ b/getgauge/python.py
@@ -1,4 +1,3 @@
-import inspect
 import sys
 import warnings
 
@@ -12,8 +11,9 @@ except ImportError:
 
 def step(step_text):
     def _step(func):
-        f_back = sys._getframe().f_back
-        registry.add_step(step_text, func, f_back.f_code.co_filename, inspect.getsourcelines(func)[1])
+        f_code = sys._getframe().f_back.f_code
+        span = {'start': f_code.co_firstlineno, 'startChar': 0, 'end': 0, 'endChar': 0}
+        registry.add_step(step_text, func, f_code.co_filename, span)
         return func
 
     return _step

--- a/getgauge/refactor.py
+++ b/getgauge/refactor.py
@@ -27,7 +27,7 @@ def refactor_step(request, response, with_location=True):
 def _refactor_content(content, info, request, with_location):
     red = RedBaron(content)
     diff = None
-    for func in red.find_all('def'):
+    for func in (n for n in red if n.type == 'def'):
         for decorator in func.decorators:
             steps = re.findall(r'[\'"](.*?)[\'"]', decorator.call.__str__())
             if len(steps) > 0 and steps[0] == info.step_text:

--- a/getgauge/registry.py
+++ b/getgauge/registry.py
@@ -40,6 +40,9 @@ class StepInfo(object):
 
     @property
     def span(self):
+        # If span is callable, lazy load span on access
+        if callable(self.__span):
+            self.__span = self.__span()
         return self.__span
 
 

--- a/getgauge/registry.py
+++ b/getgauge/registry.py
@@ -38,18 +38,8 @@ class StepInfo(object):
     def file_name(self):
         return self.__file_name
 
-    def __create_span(self):
-        try:
-            absolute_bounding_box = self.__impl.absolute_bounding_box
-            start = absolute_bounding_box.top_left
-            end = absolute_bounding_box.bottom_right
-            self.__span = {"start": start.line, "startChar": start.column, "end": end.line, "endChar": end.column}
-        except:
-            self.__span = {"start": 0, "startChar": 0, "end": 0, "endChar": 0}     
-
     @property
     def span(self):
-        if self.__span is None: self.__create_span()
         return self.__span
 
 

--- a/getgauge/static_loader.py
+++ b/getgauge/static_loader.py
@@ -42,7 +42,8 @@ def load_steps(ast, file_name):
             # Otherwise the argument must be a string
             continue
         steps = step_arg.to_python()
-        span = span_for_node(func)
+        # Lazy load span since it is very expensive to calculate
+        span = lambda: span_for_node(func)
         registry.add_step(steps, func, file_name, span)
 
 

--- a/getgauge/static_loader.py
+++ b/getgauge/static_loader.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import os
 
 from redbaron import RedBaron
@@ -7,21 +6,57 @@ from redbaron import RedBaron
 from getgauge.registry import registry
 
 
+def span_for_node(node):
+    try:
+        # For some reason RedBaron does not create absolute_bounding_box
+        # attributes for some content passed during unit test so we have
+        # to catch AttributeError here and return invalid data
+        box = node.absolute_bounding_box
+        return {
+            'start': box.top_left.line,
+            'startChar': box.top_left.column,
+            'end': box.bottom_right.line,
+            'endChar': box.bottom_right.column,
+        }
+    except AttributeError:
+        return {'start': 0, 'startChar': 0, 'end': 0, 'endChar': 0}
+
+
 def load_steps(ast, file_name):
-    if ast is not None:
-        for func in ast.find_all('def'):
-            for decorator in func.decorators:
-                if decorator.value.__str__() == 'step':
-                    steps = re.findall(
-                        r'[\'"](.*?)[\'"]', decorator.call.__str__())
-                    add_steps(file_name, func, steps)
+    for func in ast.find_all('def'):
+        # Check if function has a step decorator
+        decorator = next((d for d in func.decorators if d.name.value == 'step'), None)
+        if not decorator:
+            continue
+        # The step decorator should have at least one argument
+        args = decorator.call.value
+        if len(args) < 1:
+            continue
+        step_arg = args[0].value
+        if step_arg.type == 'list':
+            # If a list is provided as the first argument,
+            # it must have all values as strings
+            if any(v.type != 'string' for v in step_arg.value):
+                continue
+        elif step_arg.type != 'string':
+            # Otherwise the argument must be a string
+            continue
+        steps = step_arg.to_python()
+        span = span_for_node(func)
+        registry.add_step(steps, func, file_name, span)
 
 
 def generate_ast(content, file_name):
     try:
         return RedBaron(content)
-    except Exception:
-        logging.error("Failed to parse {}.".format(file_name))
+    except Exception as ex:
+        # Trim parsing error message to only include failure location
+        msg = str(ex)
+        marker = "<---- here\n"
+        marker_pos = msg.find(marker)
+        if marker_pos > 0:
+            msg = msg[:marker_pos+len(marker)]
+        logging.error("Failed to parse {}: {}".format(file_name, msg))
         return
 
 
@@ -33,20 +68,15 @@ def reload_steps(content, file_name):
 
 
 def add_steps(file_name, func, steps):
-    if len(steps) > 1:
+    if isinstance(steps, list) or isinstance(steps, str):
         registry.add_step(steps, func, file_name, None)
-    elif len(steps) == 1:
-        registry.add_step(steps[0], func, file_name, None)
 
 
 def load_files(step_impl_dir):
-    for f in os.listdir(step_impl_dir):
-        file_path = os.path.join(step_impl_dir, f)
-        if f.endswith('.py'):
-            impl_file = open(file_path, 'r+')
-            ast = generate_ast(impl_file.read(), file_path)
-            if ast is not None:
-                load_steps(ast, file_path)
-            impl_file.close()
-        elif os.path.isdir(file_path):
-            load_files(file_path)
+    for dirpath, dirs, files in os.walk(step_impl_dir):
+        py_files = (os.path.join(dirpath, f) for f in files if f.endswith('.py'))
+        for file_path in py_files:
+            with open(file_path, 'r') as impl_file:
+                ast = generate_ast(impl_file.read(), file_path)
+                if ast is not None:
+                    load_steps(ast, file_path)

--- a/getgauge/static_loader.py
+++ b/getgauge/static_loader.py
@@ -23,7 +23,7 @@ def span_for_node(node):
 
 
 def load_steps(ast, file_name):
-    for func in ast.find_all('def'):
+    for func in (n for n in ast if n.type == 'def'):
         # Check if function has a step decorator
         decorator = next((d for d in func.decorators if d.name.value == 'step'), None)
         if not decorator:

--- a/tests/test_static_loader.py
+++ b/tests/test_static_loader.py
@@ -71,7 +71,8 @@ class StaticLoaderTests(unittest.TestCase):
 
         """
         ast = generate_ast(content, "foo.py")
-        load_steps(ast, "foo.py")
+        if ast:
+            load_steps(ast, "foo.py")
 
         self.assertFalse(registry.is_implemented("print hello"))
 
@@ -121,6 +122,41 @@ class StaticLoaderTests(unittest.TestCase):
         load_steps(ast, "foo.py")
 
         self.assertTrue(registry.is_implemented("print hello {}"))
+
+    def test_loader_triple_quote_strings(self):
+        content = """
+            @step('''print hello <>''')
+            def print(arg1):
+                print(arg1)
+            """
+        ast = generate_ast(content, "foo.py")
+        load_steps(ast, "foo.py")
+
+        self.assertTrue(registry.is_implemented("print hello {}"))
+
+    def test_loader_step_indirect_argument(self):
+        content = """
+            v = 'print hello <>'
+            @step(v)
+            def print(arg1):
+                print(arg1)
+            """
+        ast = generate_ast(content, "foo.py")
+        load_steps(ast, "foo.py")
+
+        self.assertFalse(registry.is_implemented("print hello {}"))
+
+    def test_loader_non_string_argument(self):
+        content = """
+            @step(100)
+            def print(arg1):
+                print(arg1)
+            """
+        ast = generate_ast(content, "foo.py")
+        load_steps(ast, "foo.py")
+
+        self.assertFalse(registry.is_implemented("print hello {}"))
+
 
 def tearDown(self):
     registry.clear()


### PR DESCRIPTION
This PR is result of python3 f-string related failures in my test code. I realised that RedBaron was unable to parse python3 code. I rounded up following fixes into one PR for you:

 - Added exact parsing failure error message. It should help identify unsupported python3 syntax.
 - Used `to_python()` to load step arguments. This is better than using regular expressions to parse already parsed text. 
 - Used `os.walk()` instead of recursive function calls. 
 - Proper span objects are created when a step is loaded. I was not sure why this was done in the `StepInfo` class.
 - Removed usage of inspect which requires source code loading at runtime. The text returned by inspect was not being used anyway.