### PR TITLE
Update registry.py

### DIFF
--- a/getgauge/registry.py
+++ b/getgauge/registry.py
@@ -167,7 +167,7 @@ def _take_screenshot():
     temp_file = os.path.join(tempfile.gettempdir(), 'screenshot.png')
     try:
         call(['gauge_screenshot', temp_file])
-        _file = open(temp_file, 'r+b')
+        _file = open(temp_file, 'r+b', encoding='utf-8')
         data = _file.read()
         _file.close()
         return data


### PR DESCRIPTION
Running tool: gauge run d:\py\3\gauge-python-demo\specs\example.spec --simple-console --hide-suggestion
Python: 3.6.5
Traceback (most recent call last):
  File "start.py", line 65, in <module>
    main()
  File "start.py", line 29, in main
    load_implementations()
  File "start.py", line 35, in load_implementations
    load_files(d)
  File "E:\Program Files\Python36\lib\site-packages\getgauge\static_loader.py", line 47, in load_files
    ast = generate_ast(impl_file.read(), file_path)
UnicodeDecodeError: 'gbk' codec can't decode byte 0xad in position 389: illegal multibyte sequence
Error ----------------------------------