### PR TITLE
specify utf-8 encoding for file opening

### DIFF
--- a/getgauge/parser_parso.py
+++ b/getgauge/parser_parso.py
@@ -26,7 +26,7 @@ class ParsoPythonFile(object):
             # For now we can make a compromise by reading the file ourselves
             # and passing content to parse() function.
             if content is None:
-                with open(file_path) as f:
+                with open(file_path, encoding='utf-8') as f:
                     content = f.read()
             py_tree = _parser.parse(
                 content, path=file_path, error_recovery=False)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -44,6 +44,22 @@ class CommonPythonFileTests(object):
         pf = self.parse(content)
         self.assertIsNone(pf)
 
+    def test_can_parse_chinese_content_directly(self):
+        content = dedent('''\
+        class test:
+            @step("打印你好")
+            def print_hello():
+                print("hello")
+
+            @step('打印 <hello>.')
+            def print_word(word):
+                print(word)
+
+        ''')
+        pf = self.parse(content)
+        self.assertIsNotNone(pf)
+        self.assertEqual(pf.get_code(), content)
+
     def test_iter_steps_loads_steps_from_content(self):
         content = dedent('''\
         @step("print hello")


### PR DESCRIPTION
**problem**: `UnicodeDecodeError` on Windows 10 when regional language is Chinese. This is because when regional language is Chinese, system encoding is gbk by default, and all Chinese Character in `.spec` and `.py` file would fail to load.
**related issue**: https://github.com/getgauge/gauge/issues/1228
**solution**: specify 'utf-8' encoding when opening python files.