### PR TITLE
Update parser.py

### DIFF
--- a/getgauge/parser.py
+++ b/getgauge/parser.py
@@ -13,7 +13,7 @@ class Parser(object):
         """
         try:
             if content is None:
-                with open(file_path) as f:
+                with open(file_path, encoding='utf-8') as f:
                     content = f.read()
             py_tree = RedBaron(content)
             return Parser(file_path, py_tree)


### PR DESCRIPTION
fix 'gbk' codec can't decode byte 0xaf in position 1036: illegal multibyte sequence.
30-06-2022 17:14:37.117 [python] [ERROR] Failed to parse C:\Users\yuweipeng03751\Documents\Project\py\yunhejia-api-test-master-aab799571d7f6539bd5bbd1a6b9bb14e0f0518a7\step_impl\step_impl.py: 'gbk' codec can't decode byte 0xaf in position 1036: illegal multibyte sequence
30-06-2022 17:14:37.117 [Gauge] [DEBUG] Successfully made the connection with runner with port: 60628
30-06-2022 17:14:37.117 [Gauge] [DEBUG] Validation started.
30-06-2022 17:14:37.127 [Gauge] [ERROR] [ValidationError] C:\Users\yuweipeng03751\Documents\Project\py\yunhejia-api-test-master-aab799571d7f6539bd5bbd1a6b9bb14e0f0518a7\specs\00-在线楼盘.spec:8 Step implementation not found => '检查请求方式为get的URL <table>'
30-06-2022 17:14:37.127 [Gauge] [ERROR] [ValidationError] C:\Users\yuweipeng03751\Documents\Project\py\yunhejia-api-test-master-aab799571d7f6539bd5bbd1a6b9bb14e0f0518a7\specs\00-在线楼盘.spec:18 Step implementation not found => '检查请求方式为post的URL <table>'

This is my commit message
Signed-off-by: yuweipeng <yicaifeitian@163.com>

By making a contribution to this project, I certify that:

The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

The contribution was provided directly to me by some other person who certified 1., 2. or 3. and I have not modified it.

I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.