### PR TITLE
Correctly loading the methods from relatively imported classes

### DIFF
--- a/getgauge/impl_loader.py
+++ b/getgauge/impl_loader.py
@@ -91,12 +91,12 @@ def _import_file(base_dir, file_path):
                 file = inspect.getfile(c[1])
                 # Create instance of step implementation class.
                 if _has_methods_with_gauge_decoratores(c[1]):
-                    update_step_resgistry_with_class(c[1](), file_path) # c[1]() will create a new instance of the class
+                    update_step_registry_with_class(c[1](), file_path) # c[1]() will create a new instance of the class
     except:
         logger.fatal('Exception occurred while loading step implementations from file: {}.\n{}'.format(rel_path, traceback.format_exc()))
 
 # Inject instace in each class method (hook/step)
-def update_step_resgistry_with_class(instance, file_path):
+def update_step_registry_with_class(instance, file_path):
     # Resolve the absolute path from relative path
     file_path = os.path.abspath(file_path) if '..' in file_path else file_path
     method_list = registry.get_all_methods_in(file_path)

--- a/getgauge/impl_loader.py
+++ b/getgauge/impl_loader.py
@@ -97,7 +97,7 @@ def _import_file(base_dir, file_path):
 
 # Inject instace in each class method (hook/step)
 def update_step_resgistry_with_class(instance, file_path):
-    # Resole the absolute path from relative path
+    # Resolve the absolute path from relative path
     file_path = os.path.abspath(file_path) if '..' in file_path else file_path
     for info in registry.get_all_methods_in(file_path):
         class_methods = [x[0] for x in inspect.getmembers(instance, inspect.ismethod)]

--- a/getgauge/impl_loader.py
+++ b/getgauge/impl_loader.py
@@ -97,6 +97,8 @@ def _import_file(base_dir, file_path):
 
 # Inject instace in each class method (hook/step)
 def update_step_resgistry_with_class(instance, file_path):
+    # Resole the absolute path from relative path
+    file_path = os.path.abspath(file_path) if '..' in file_path else file_path
     for info in registry.get_all_methods_in(file_path):
         class_methods = [x[0] for x in inspect.getmembers(instance, inspect.ismethod)]
         if info.impl.__name__ in class_methods:

--- a/getgauge/impl_loader.py
+++ b/getgauge/impl_loader.py
@@ -99,11 +99,12 @@ def _import_file(base_dir, file_path):
 def update_step_resgistry_with_class(instance, file_path):
     # Resolve the absolute path from relative path
     file_path = os.path.abspath(file_path) if '..' in file_path else file_path
-    for info in registry.get_all_methods_in(file_path):
+    method_list = registry.get_all_methods_in(file_path)
+    for info in method_list:
         class_methods = [x[0] for x in inspect.getmembers(instance, inspect.ismethod)]
         if info.impl.__name__ in class_methods:
             info.instance = instance
-
+    return method_list
 
 def _get_version():
     json_data = open(PLUGIN_JSON).read()

--- a/python.json
+++ b/python.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Python support for gauge",
   "run": {
     "windows": [

--- a/python.json
+++ b/python.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Python support for gauge",
   "run": {
     "windows": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ baron==0.10.1
 bleach==6.1.0
 certifi==2024.6.2
 charset-normalizer==3.3.2
-debugpy==1.8.1
+debugpy==1.8.2
 docutils==0.20.1
 grpcio==1.62.2
 grpcio-tools==1.62.2
 idna==3.7
-importlib-metadata==7.2.1
+importlib-metadata==8.0.0
 jaraco.classes==3.4.0
 keyring==25.2.1
 markdown-it-py==3.0.0
@@ -25,7 +25,7 @@ requests-toolbelt==1.0.0
 rfc3986==2.0.0
 rich==13.7.1
 rply==0.7.8
-setuptools==70.1.0
+setuptools==70.1.1
 six==1.16.0
 twine==5.1.0
 urllib3==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,6 @@ rply==0.7.8
 setuptools==70.0.0
 six==1.16.0
 twine==5.1.0
-urllib3==2.2.1
+urllib3==2.2.2
 webencodings==0.5.1
 zipp==3.19.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ docutils==0.20.1
 grpcio==1.62.2
 grpcio-tools==1.62.2
 idna==3.7
-importlib-metadata==7.1.0
+importlib-metadata==7.2.1
 jaraco.classes==3.4.0
 keyring==25.2.1
 markdown-it-py==3.0.0
@@ -25,7 +25,7 @@ requests-toolbelt==1.0.0
 rfc3986==2.0.0
 rich==13.7.1
 rply==0.7.8
-setuptools==70.0.0
+setuptools==70.1.0
 six==1.16.0
 twine==5.1.0
 urllib3==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ keyring==25.2.1
 markdown-it-py==3.0.0
 mdurl==0.1.2
 more-itertools==10.3.0
-pkginfo==1.11.1
+pkginfo>=1.8.1
 protobuf==4.25.3
 pyfakefs==5.5.0
 Pygments==2.18.0
@@ -27,7 +27,7 @@ rich==13.7.1
 rply==0.7.8
 setuptools==70.1.1
 six==1.16.0
-twine==5.1.0
+twine==5.1.1
 urllib3==2.2.2
 webencodings==0.5.1
 zipp==3.19.2

--- a/test_relative_import/relative_import_class.py
+++ b/test_relative_import/relative_import_class.py
@@ -1,0 +1,21 @@
+from getgauge.python import step, Messages
+
+
+class BaseSample:
+    def __init__(self) -> None:
+        pass
+
+class Sample(BaseSample):
+    def __init__(self) -> None:
+        pass
+
+    # Gauge step implementation in a class
+    @step('Greet <name> from inside the class')
+    def greetings_from_class(self, name):
+        Messages.write_message("Hello from inside the class, {0}".format(name))
+
+
+# Gauge step implementation outside class
+@step('Greet <name> from outside the class')
+def greetings_from_outside_the_class(name):
+    Messages.write_message("Hello from outside the class, {0}".format(name))

--- a/tests/test_impl_loader.py
+++ b/tests/test_impl_loader.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 from test_relative_import.relative_import_class import Sample
-from getgauge.impl_loader import update_step_resgistry_with_class
+from getgauge.impl_loader import update_step_registry_with_class
 
 
 class ImplLoaderTest(unittest.TestCase):
@@ -12,9 +12,11 @@ class ImplLoaderTest(unittest.TestCase):
     def test_update_step_resgistry_with_class(self):
         curr_dir = os.getcwd()
         os.chdir('tests')
-        method_list = update_step_resgistry_with_class(Sample(), self.relative_file_path)
+        method_list = update_step_registry_with_class(Sample(), self.relative_file_path)
         os.chdir(curr_dir)
-        self.assertEqual(2, len(method_list))
+        self.assertEqual(["Greet <name> from inside the class", 
+                          "Greet <name> from outside the class"], 
+                          [method.step_text for method in method_list])
 
     
 if __name__ == '__main__':

--- a/tests/test_impl_loader.py
+++ b/tests/test_impl_loader.py
@@ -1,0 +1,21 @@
+import os
+import unittest
+
+from test_relative_import.relative_import_class import Sample
+from getgauge.impl_loader import update_step_resgistry_with_class
+
+
+class ImplLoaderTest(unittest.TestCase):
+    def setUp(self):
+        self.relative_file_path = os.path.join('..', 'test_relative_import', 'relative_import_class.py')
+
+    def test_update_step_resgistry_with_class(self):
+        curr_dir = os.getcwd()
+        os.chdir('tests')
+        method_list = update_step_resgistry_with_class(Sample(), self.relative_file_path)
+        os.chdir(curr_dir)
+        self.assertEqual(2, len(method_list))
+
+    
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
After merging #360 all the previous issues were fixed but when I created step implementations inside a class and tried use those steps inside specs, I was getting an error with positional arguments missing.

This issue arises because the `update_step_resgistry_with_class()` method inside the `impl_loader.py` file is unable to fetch all the methods inside that step implementation file inside `get_all_methods_in()` method due to the `file_path` being a relative file path.

Resolving the relative file path into an absolute file path inside `update_step_resgistry_with_class()` method #365

Hey @BugDiver, @zabil, can you please help me merge this PR to resolve this issue.
Apologies for this follow-up PR, missed this update in the previous PR.

Thanks!😄