### PR TITLE
Migrate from pkg_resources to importlib.metadata

### DIFF
--- a/check_and_install_getgauge.py
+++ b/check_and_install_getgauge.py
@@ -2,7 +2,7 @@ import json
 import sys
 from subprocess import check_output
 
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 
 
 def get_version():
@@ -29,10 +29,10 @@ def assert_versions():
     expected_gauge_version = python_plugin_version
 
     try:
-        getgauge_version = pkg_resources.get_distribution('getgauge').version
+        getgauge_version = version('getgauge')
         if getgauge_version != expected_gauge_version:
             install_getgauge("getgauge=="+expected_gauge_version)
-    except pkg_resources.DistributionNotFound:
+    except PackageNotFoundError:
         install_getgauge("getgauge=="+expected_gauge_version)
 
 

--- a/python.json
+++ b/python.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Python support for gauge",
   "run": {
     "windows": [


### PR DESCRIPTION
This PR changes `check_and_install_gauge.py` script from use of deprecated `pkg_resources` package to `importlib.metadata`. Local tests are passing, the change should have no visible impact on users.

Closes #373 