### PR TITLE
Change comparison `is` to `==` to avoid `SyntaxWarning`

### DIFF
--- a/getgauge/python.py
+++ b/getgauge/python.py
@@ -2,7 +2,7 @@ import sys
 import warnings
 from getgauge.registry import registry, MessagesStore, ScreenshotsStore
 
-if sys.version_info[0] is 3:
+if sys.version_info[0] == 3:
     from collections.abc import MutableMapping
 else:
     from collections import MutableMapping


### PR DESCRIPTION
This fixes `SyntaxWarning: "is" with a literal. Did you mean "=="?` from Python 3.12.