### PR TITLE
Update Python unittests and apply Python standard

### DIFF
--- a/getgauge/parser.py
+++ b/getgauge/parser.py
@@ -93,7 +93,7 @@ class Parser(object):
             arg_node = decorator.call.value[0].value
             if step == step_text:
                 return arg_node, func
-            elif isinstance(step, list) and step_text in step:
+            if isinstance(step, list) and step_text in step:
                 step_node = arg_node[step.index(step_text)]
                 return step_node, func
         return None, None

--- a/getgauge/python.py
+++ b/getgauge/python.py
@@ -66,9 +66,11 @@ def custom_screen_grabber(func):
     registry.set_screenshot_provider(func, False)
     return func
 
+
 def custom_screenshot_writer(func):
     registry.set_screenshot_provider(func, True)
     return func
+
 
 def _warn_screenshot_deprecation(old_function, new_function):
     warnings.warn(
@@ -172,12 +174,8 @@ class Specification:
         return self.__tags
 
     def __str__(self):
-        return "Specification: {{ name: {}, is_failing: {}, tags: {}, file_name: {} }}".format(self.name,
-                                                                                               str(
-                                                                                                   self.is_failing),
-                                                                                               ", ".join(
-                                                                                                   self.tags),
-                                                                                               self.file_name)
+        s = "Specification: {{ name: {}, is_failing: {}, tags: {}, file_name: {} }}"
+        return s.format(self.name, str(self.is_failing), ", ".join(self.tags), self.file_name)
 
     def __eq__(self, other):
         return self.__str__() == other.__str__()
@@ -202,8 +200,8 @@ class Scenario:
         return self.__tags
 
     def __str__(self):
-        return "Scenario: {{ name: {}, is_failing: {}, tags: {} }}".format(self.name, str(self.is_failing),
-                                                                           ", ".join(self.tags))
+        s = "Scenario: {{ name: {}, is_failing: {}, tags: {} }}"
+        return s.format(self.name, str(self.is_failing), ", ".join(self.tags))
 
     def __eq__(self, other):
         return self.__str__() == other.__str__()

--- a/getgauge/registry.py
+++ b/getgauge/registry.py
@@ -2,8 +2,8 @@ import inspect
 import os
 import re
 import sys
-from uuid import uuid1
 from subprocess import call
+from uuid import uuid1
 
 from getgauge import logger
 
@@ -218,13 +218,13 @@ def _filter_hooks(tags, hooks):
             continue
         for tag in tags:
             hook_tags = hook_tags.replace('<{}>'.format(tag), 'True')
-        if eval(re.sub('<[^<]+?>', 'False', hook_tags)):
+        if eval(re.sub(r'<[^<]+?>', 'False', hook_tags)):
             filtered_hooks.append(hook)
     return filtered_hooks
 
 
 def _get_step_value(step_text):
-    return re.sub('(<.*?>)', '{}', step_text)
+    return re.sub(r'(<.*?>)', '{}', step_text)
 
 
 def _take_screenshot():
@@ -263,23 +263,26 @@ class ScreenshotsStore:
         if not registry.is_screenshot_writer:
             screenshot_file = _uniqe_screenshot_file()
             content = registry.screenshot_provider()()
-            file = open(screenshot_file, "wb")
-            file.write(content)
-            file.close()
+            with open(screenshot_file, "wb") as file:
+                file.write(content)
+                file.close()
             return os.path.basename(screenshot_file)
         screenshot_file = registry.screenshot_provider()()
-        if(not os.path.isabs(screenshot_file)):
+        if not os.path.isabs(screenshot_file):
             screenshot_file = os.path.join(_screenshots_dir(), screenshot_file)
-        if(not os.path.exists(screenshot_file)):
-            logger.warning("Screenshot file {0} does not exists.".format(screenshot_file))
+        if not os.path.exists(screenshot_file):
+            logger.warning(
+                "Screenshot file {0} does not exists.".format(screenshot_file))
         return os.path.basename(screenshot_file)
 
     @staticmethod
     def clear():
         ScreenshotsStore.__screenshots = []
 
+
 def _uniqe_screenshot_file():
     return os.path.join(_screenshots_dir(), "screenshot-{0}.png".format(uuid1().int))
+
 
 def _screenshots_dir():
     return os.getenv('gauge_screenshots_dir')

--- a/getgauge/static_loader.py
+++ b/getgauge/static_loader.py
@@ -1,12 +1,13 @@
-import os
-from getgauge.registry import registry
+import glob
+
 from getgauge.parser import Parser
+from getgauge.registry import registry
 
 
-def load_steps(python_file):
-    for funcStep in python_file.iter_steps():
-        registry.add_step(funcStep[0], funcStep[1],
-                          python_file.file_path, funcStep[2])
+def load_steps(python_file: Parser):
+    for func_step in python_file.iter_steps():
+        registry.add_step(func_step[0], func_step[1],
+                          python_file.file_path, func_step[2])
 
 
 def reload_steps(file_path, content=None):
@@ -18,9 +19,7 @@ def reload_steps(file_path, content=None):
 
 def load_files(step_impl_dirs):
     for step_impl_dir in step_impl_dirs:
-        for dirpath, _, files in os.walk(step_impl_dir):
-                py_files = (os.path.join(dirpath, f) for f in files if f.endswith('.py'))
-                for file_path in py_files:
-                        pf = Parser.parse(file_path)
-                        if pf:
-                                load_steps(pf)
+        for file_path in glob.glob(f"{step_impl_dir}/**/*.py", recursive=True):
+            pf = Parser.parse(file_path)
+            if pf:
+                load_steps(pf)

--- a/getgauge/util.py
+++ b/getgauge/util.py
@@ -34,9 +34,9 @@ def get_impl_files():
 
 def read_file_contents(file_name):
     if os.path.isfile(file_name):
-        f = open(file_name)
-        content = f.read().replace('\r\n', '\n')
-        f.close()
+        with open(file_name, "r", encoding="utf-8") as f:
+            content = f.read().replace('\r\n', '\n')
+            f.close()
         return content
     return None
 
@@ -46,6 +46,6 @@ def get_file_name(prefix='', counter=0):
     file_name = os.path.join(get_step_impl_dirs()[0], name)
     if not os.path.exists(file_name):
         return file_name
-    else:
-        counter = counter + 1
-        return get_file_name('_{}'.format(counter), counter)
+
+    counter = counter + 1
+    return get_file_name('_{}'.format(counter), counter)

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import tempfile
 import unittest
 
@@ -49,7 +48,7 @@ def assert_default_vowels(arg0):
         param_position.newPosition = 1
         request.refactorRequest.paramPositions.extend([position, param_position])
 
-        processor.refactor_step(request.refactorRequest, response, None)
+        processor.refactor_step(request.refactorRequest, response)
         actual_data = self.getActualText()
 
         self.assertEqual(Message.RefactorResponse, response.messageType)
@@ -83,7 +82,7 @@ def assert_default_vowels(arg0, arg1):
         param_position.newPosition = 1
         request.refactorRequest.paramPositions.extend([position, param_position])
 
-        processor.refactor_step(request.refactorRequest, response, None)
+        processor.refactor_step(request.refactorRequest, response)
         actual_data = self.getActualText()
 
         self.assertEqual(Message.RefactorResponse, response.messageType)
@@ -117,7 +116,7 @@ def assert_default_vowels(arg0, arg1):
         param_position.newPosition = 1
         request.refactorRequest.paramPositions.extend([position, param_position])
 
-        processor.refactor_step(request.refactorRequest, response, None)
+        processor.refactor_step(request.refactorRequest, response)
         actual_data = self.getActualText()
 
         self.assertEqual(Message.RefactorResponse, response.messageType)
@@ -142,7 +141,7 @@ def assert_default_vowels(arg0, arg1):
         request.refactorRequest.newStepValue.parameterizedStepValue = 'Vowels in English language is.'
         request.refactorRequest.newStepValue.stepValue = 'Vowels in English language is.'
 
-        processor.refactor_step(request.refactorRequest, response, None)
+        processor.refactor_step(request.refactorRequest, response)
 
         actual_data = self.getActualText()
 
@@ -173,7 +172,7 @@ def assert_default_vowels():
         position.newPosition = 0
         request.refactorRequest.paramPositions.extend([position])
 
-        processor.refactor_step(request.refactorRequest, response, None)
+        processor.refactor_step(request.refactorRequest, response)
 
         actual_data = self.getActualText()
 
@@ -204,7 +203,7 @@ def assert_default_vowels(arg0):
         param_position.newPosition = 0
         request.refactorRequest.paramPositions.extend([param_position])
 
-        processor.refactor_step(request.refactorRequest, response, None)
+        processor.refactor_step(request.refactorRequest, response)
 
         actual_data = self.getActualText()
 
@@ -242,7 +241,7 @@ def assert_default_vowels(arg1):
         param2_position.newPosition = 1
         request.refactorRequest.paramPositions.extend([param1_position, param2_position])
 
-        processor.refactor_step(request.refactorRequest, response, None)
+        processor.refactor_step(request.refactorRequest, response)
 
         actual_data = self.getActualText()
 
@@ -280,7 +279,7 @@ is <vowels> <bsdfdsf>.'
 
         old_content = self.getActualText()
 
-        processor.refactor_step(request.refactorRequest, response, None)
+        processor.refactor_step(request.refactorRequest, response)
 
         expected = """@step("Vowels in English language is <vowels> <bsdfdsf>.")
 def assert_default_vowels(arg0, arg1):
@@ -319,7 +318,7 @@ def assert_default_vowels(arg0, arg1):
 
         old_content = self.getActualText()
 
-        processor.refactor_step(request.refactorRequest, response, None)
+        processor.refactor_step(request.refactorRequest, response)
 
         self.assertEqual(Message.RefactorResponse, response.messageType)
         self.assertTrue(response.refactorResponse.success, response.refactorResponse.error)
@@ -345,4 +344,3 @@ def assert_default_vowels(arg0, arg1):
         _file.write(RefactorTests.data)
         _file.close()
         return actual_data
-


### PR DESCRIPTION
While investigating into "Add support to skip scenarios on runtime" I stumbled about several smaller code-smells reported by Pylance. Boy-scout-rule-wise I would like to contribute them as part of this PR.

Out of curiosity: Is there a guideline which Python versions are supported? Could not find relevant information in the Gauge docs.