### PR TITLE
Skip test scenarios at runtime

### DIFF
--- a/getgauge/exceptions.py
+++ b/getgauge/exceptions.py
@@ -1,0 +1,4 @@
+class SkipScenarioException(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message

--- a/getgauge/executor.py
+++ b/getgauge/executor.py
@@ -4,9 +4,10 @@ import sys
 import time
 import traceback
 
-from getgauge.messages.messages_pb2 import ExecutionStatusResponse, Message
+from getgauge.exceptions import SkipScenarioException
+from getgauge.messages.messages_pb2 import ExecutionStatusResponse
 from getgauge.messages.spec_pb2 import ProtoExecutionResult
-from getgauge.registry import MessagesStore, ScreenshotsStore, registry
+from getgauge.registry import MessagesStore, ScreenshotsStore
 
 
 def create_execution_status_response():
@@ -23,7 +24,8 @@ def run_hook(request, hooks, execution_info):
     return response
 
 
-def _false(func, exception): return False
+def _false(func, exception):
+    return False
 
 
 def execute_method(params, step, response, is_continue_on_failure=_false):
@@ -31,6 +33,9 @@ def execute_method(params, step, response, is_continue_on_failure=_false):
     try:
         params = _get_args(params, step)
         step.impl(*params)
+    except SkipScenarioException as e:
+        response.executionResult.skipScenario = True
+        MessagesStore.write_message(str(e))
     except Exception as e:
         _add_exception(e, response, is_continue_on_failure(step.impl, e))
     response.executionResult.executionTime = _current_time() - start
@@ -38,7 +43,8 @@ def execute_method(params, step, response, is_continue_on_failure=_false):
     response.executionResult.screenshotFiles.extend(ScreenshotsStore.pending_screenshots())
 
 
-def _current_time(): return int(round(time.time() * 1000))
+def _current_time():
+    return int(round(time.time() * 1000))
 
 
 def _get_args(params, hook_or_step):
@@ -57,7 +63,7 @@ def _add_exception(e, response, continue_on_failure):
         screenshot = ScreenshotsStore.capture_to_file()
         response.executionResult.failureScreenshotFile = screenshot
     response.executionResult.failed = True
-    message = e.__str__()
+    message = str(e)
     if not message:
         message = "Exception occurred"
     response.executionResult.errorMessage = message

--- a/python.json
+++ b/python.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Python support for gauge",
   "run": {
     "windows": [


### PR DESCRIPTION
With this PR I would like to introduce the feature to skip scenarios at runtime, related to this issue: https://github.com/getgauge/gauge-python/issues/390

I've two question though:

How to test this kind of processing? I was unable to find a great way to test that this exception is raised and handled correctly.
How can I set the step result to skipped=true? At the moment the feature works fine, but the step with the SkipScenarioException is shown as "passed" in the HTML report.

PS: Now with signed commit .. 😏 