### PR TITLE
Enable test coverage report according to README

### DIFF
--- a/build.py
+++ b/build.py
@@ -102,13 +102,17 @@ Options:
 """
 
 
-def run_tests():
+def run_tests() -> int:
     pp = "PYTHONPATH"
     os.environ[pp] = str(ROOT_DIR)
     exit_code = 0
-    for file_name_path in glob.glob(f"{ROOT_DIR}/tests/**/test_*.py", recursive=True):
-        exit_code = call([sys.executable, file_name_path]
-                         ) if exit_code == 0 else exit_code
+    all_python_test_files = glob.glob(f"{ROOT_DIR}/tests/**/test_*.py", recursive=True)
+    for i, file_name_path in enumerate(all_python_test_files):
+        command = ["coverage", "run", file_name_path]
+        exit_code = call(command) if exit_code == 0 else exit_code
+        # Keep coverage files
+        os.rename(".coverage", f".coverage.{i}")
+    call(["coverage", "combine"])
     return exit_code
 
 

--- a/getgauge/exceptions.py
+++ b/getgauge/exceptions.py
@@ -1,0 +1,4 @@
+class MultipleImplementationFoundException(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message

--- a/getgauge/refactor.py
+++ b/getgauge/refactor.py
@@ -1,4 +1,5 @@
-from getgauge.messages.messages_pb2 import RefactorResponse, TextDiff
+from getgauge.exceptions import MultipleImplementationFoundException
+from getgauge.messages.messages_pb2 import TextDiff
 from getgauge.messages.spec_pb2 import Span
 from getgauge.parser import Parser
 from getgauge.registry import registry
@@ -6,7 +7,7 @@ from getgauge.registry import registry
 
 def refactor_step(request, response):
     if registry.has_multiple_impls(request.oldStepValue.stepValue):
-        raise Exception('Multiple Implementation found for `{}`'.format(
+        raise MultipleImplementationFoundException('Multiple Implementation found for `{}`'.format(
             request.oldStepValue.parameterizedStepValue
         ))
     info = registry.get_info_for(request.oldStepValue.stepValue)
@@ -18,7 +19,7 @@ def refactor_step(request, response):
     )
     content = impl_file.get_code()
     if request.saveChanges:
-        with open(info.file_name, 'w') as f:
+        with open(info.file_name, 'w', encoding="utf-8") as f:
             f.write(content)
     response.success = True
     response.filesChanged.append(info.file_name)
@@ -31,6 +32,6 @@ def refactor_step(request, response):
 
 def _new_parameter_positions(request):
     moved_pos = list(range(len(request.paramPositions)))
-    for index, position in enumerate(request.paramPositions):
+    for position in request.paramPositions:
         moved_pos[position.newPosition] = position.oldPosition
     return moved_pos

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ twine==5.1.1
 urllib3==2.2.3
 webencodings==0.5.1
 zipp==3.20.2
+coverage==7.6.1

--- a/tests/test_impl_loader.py
+++ b/tests/test_impl_loader.py
@@ -1,15 +1,15 @@
 import os
 import unittest
 
-from test_relative_import.relative_import_class import Sample
 from getgauge.impl_loader import update_step_registry_with_class
+from test_relative_import.relative_import_class import Sample
 
 
 class ImplLoaderTest(unittest.TestCase):
     def setUp(self):
         self.relative_file_path = os.path.join('..', 'test_relative_import', 'relative_import_class.py')
 
-    def test_update_step_resgistry_with_class(self):
+    def test_update_step_registry_with_class(self):
         curr_dir = os.getcwd()
         os.chdir('tests')
         method_list = update_step_registry_with_class(Sample(), self.relative_file_path)
@@ -18,6 +18,6 @@ class ImplLoaderTest(unittest.TestCase):
                           "Greet <name> from outside the class"], 
                           [method.step_text for method in method_list])
 
-    
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As per README.md, you should be able to create a coverage report after executing the tests. Apparently this was not possible at all since the test cases were executed without using the Python module "coverage".

README.md:

> ##### Tests Coverage
> ```
> python build.py --test
> coverage report -m
> ```

With my changes you can execute `coverage html` or `coverage report -m` successfully.

Besides the required changes in `build.py`, I resolved even more code-smells like "unused variable".