### PR TITLE
Allow GAUGE_PYTHON_COMMAND to contain spaces

### DIFF
--- a/python.json
+++ b/python.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Python support for gauge",
   "run": {
     "windows": [

--- a/start.bat
+++ b/start.bat
@@ -1,4 +1,4 @@
 @echo off
-IF "%GAUGE_PYTHON_COMMAND%"=="" (SET GAUGE_PYTHON_COMMAND="python")
-%GAUGE_PYTHON_COMMAND% check_and_install_getgauge.py
-%GAUGE_PYTHON_COMMAND% -u start.py %1
+IF "%GAUGE_PYTHON_COMMAND%"=="" (SET GAUGE_PYTHON_COMMAND=python)
+"%GAUGE_PYTHON_COMMAND%" check_and_install_getgauge.py
+"%GAUGE_PYTHON_COMMAND%" -u start.py %1


### PR DESCRIPTION
Fixes #437 