### PR TITLE
Decouple build steps to be more flexible

### DIFF
--- a/build.py
+++ b/build.py
@@ -38,8 +38,10 @@ def install():
     call(install_cmd)
     sys.exit(exit_code)
 
+
 def in_venv():
     return sys.prefix != sys.base_prefix
+
 
 def create_setup_file():
     with open("setup.tmpl", "r", encoding="utf-8") as tmpl:
@@ -98,8 +100,10 @@ def copy(src, dest):
 
 usage = """
 Usage: python build.py --[option]
+Example: python build.py --test --install
 
 Options:
+    --dist    :     creates the distributable.
     --test    :     runs unit tests.
     --install :     installs python plugin and generates the pip package
 """
@@ -112,26 +116,31 @@ def run_tests() -> int:
     all_python_test_files = glob.glob(f"{ROOT_DIR}/tests/**/test_*.py", recursive=True)
     for i, file_name_path in enumerate(all_python_test_files):
         command = ["coverage", "run", file_name_path]
-        exit_code = call(command) if exit_code == 0 else exit_code
+
+        exit_code = call(command)
+        if exit_code != 0:
+            break
+
         # Keep coverage files
         os.rename(".coverage", f".coverage.{i}")
+
     call(["coverage", "combine"])
     return exit_code
 
 
 def main():
-    if len(sys.argv) < 2:
+    if len(sys.argv) < 2 or '--help' in sys.argv:
         print(usage)
     else:
-        if sys.argv[1] == '--dist':
-            create_zip()
-            generate_package()
-        else:
+        if '--test' in sys.argv:
             exit_code = run_tests()
             if exit_code != 0:
                 sys.exit(exit_code)
-            elif sys.argv[1] == '--install':
-                install()
+        if '--dist' in sys.argv:
+            create_zip()
+            generate_package()
+        if '--install' in sys.argv:
+            install()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As part of this PR I would like to decouple the execution of tests and the local installation of the plugin. In one of my Pull-Requests I wanted to have a quick feedback if the changes are OK without the installation as I was not done yet. To allow users customized options, they are simply decoupled. Install without running tests? No issue.

❌ `python build.py --test --install` was not installing anything before my change
💹 `python build.py --test --install` is running the tests and installs gauge-python afterwards

On top, if you have test failures, the coverage file was not created as part of the `coverage run ...` command, so that the line `os.rename(".coverage", f".coverage.{i}")` failed: no file available to rename --> FileNotFoundError exception. To overcome this behaviour, I am using the exit-code information to break the look immediately.